### PR TITLE
feat: add support for isMintingPaused and getTotalSupply

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -686,6 +686,7 @@ pub trait ElvenTools {
         left_tokens
     }
 
+    // Get the tokens left to mint
     #[view(getTotalTokensLeft)]
     fn total_tokens_left(&self) -> u32 {
         let minted_tokens = self.minted_indexes_total().get();
@@ -693,6 +694,14 @@ pub trait ElvenTools {
         let left_tokens: u32 = amount_of_tokens - minted_tokens as u32;
 
         left_tokens
+    }
+
+    // Get the total amount of tokens
+    #[view(getTotalTokens)]
+    fn total_tokens(&self) -> u32 {
+        let amount_of_tokens = self.amount_of_tokens_total().get();
+
+        amount_of_tokens
     }
 
     #[view(getMintedPerAddressPerDrop)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -730,6 +730,10 @@ pub trait ElvenTools {
         self.allowlist().len()
     }
 
+    #[view(getTotalSupply)]
+    #[storage_mapper("amountOfTokensTotal")]
+    fn amount_of_tokens_total(&self) -> SingleValueMapper<u32>;
+
     #[view(getNftTokenId)]
     #[storage_mapper("nftTokenId")]
     fn nft_token_id(&self) -> SingleValueMapper<TokenIdentifier>;
@@ -766,6 +770,10 @@ pub trait ElvenTools {
     #[storage_mapper("isDropActive")]
     fn is_drop_active(&self) -> SingleValueMapper<bool>;
 
+    #[view(isMintingPaused)]
+    #[storage_mapper("paused")]
+    fn paused(&self) -> SingleValueMapper<bool>;
+
     #[storage_mapper("lastDrop")]
     fn last_drop(&self) -> SingleValueMapper<u16>;
 
@@ -784,9 +792,6 @@ pub trait ElvenTools {
     #[storage_mapper("file_extension")]
     fn file_extension(&self) -> SingleValueMapper<ManagedBuffer>;
 
-    #[storage_mapper("amountOfTokensTotal")]
-    fn amount_of_tokens_total(&self) -> SingleValueMapper<u32>;
-
     #[storage_mapper("mintedIndexesTotal")]
     fn minted_indexes_total(&self) -> SingleValueMapper<u32>;
 
@@ -795,9 +800,6 @@ pub trait ElvenTools {
 
     #[storage_mapper("royalties")]
     fn royalties(&self) -> SingleValueMapper<BigUint>;
-
-    #[storage_mapper("paused")]
-    fn paused(&self) -> SingleValueMapper<bool>;
 
     #[storage_mapper("tags")]
     fn tags(&self) -> SingleValueMapper<ManagedBuffer>;

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -23,11 +23,13 @@ elrond_wasm_node::wasm_endpoints! {
         getProvenanceHash
         getTokensLimitPerAddressPerDrop
         getTokensLimitPerAddressTotal
+        getTotalSupply
         getTotalTokens
         getTotalTokensLeft
         giveaway
         isAllowlistEnabled
         isDropActive
+        isMintingPaused
         issueToken
         mint
         pauseMinting

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -23,6 +23,7 @@ elrond_wasm_node::wasm_endpoints! {
         getProvenanceHash
         getTokensLimitPerAddressPerDrop
         getTokensLimitPerAddressTotal
+        getTotalTokens
         getTotalTokensLeft
         giveaway
         isAllowlistEnabled


### PR DESCRIPTION
Added a getter for the internally stored `amount_of_tokens_total` so that front-ends can query for the total number of tokens.


References: https://github.com/ElvenTools/elven-nft-minter-sc/issues/29